### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/snus-kin/sphinx-ts/security/code-scanning/2](https://github.com/snus-kin/sphinx-ts/security/code-scanning/2)

To fix the problem, an explicit `permissions` block should be added to the `build` job in `.github/workflows/ci.yml`. This block should restrict permissions for `GITHUB_TOKEN` to the minimum required. For the given steps (checking out code, installing dependencies, building, and uploading artifacts), the minimal starting point is `contents: read`, as none of the steps require write access to the repository, issues, or PRs. The `publish` job already sets the necessary permissions. The fix is to add:

```yaml
permissions:
  contents: read
```

to lines immediately after `runs-on: ubuntu-latest` in the `build` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
