### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/snus-kin/sphinx-ts/security/code-scanning/1](https://github.com/snus-kin/sphinx-ts/security/code-scanning/1)

To fix this problem, we must add a `permissions` key either globally (at the top of the workflow, affecting all jobs that don’t specify their own permissions), or per job for jobs that lack it. Since the `publish` job already specifies its own permissions, we can cover the `test` and `build` jobs with a single top-level permissions block right below `name: CI/CD Pipeline`. The recommended minimal permissions for most CI jobs that only read code are `contents: read`, which is suitable for the steps present (no repo writes, only install/build/etc.). If ever more writes or admin actions are needed, they can be enabled for specific jobs or steps.

1. Edit `.github/workflows/ci.yml`.
2. Insert:
   ```yaml
   permissions:
     contents: read
   ```
   After the `name:` and before the `on:` block.

No external dependencies, imports, or new methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
