### PR TITLE
feat: implement source linking functionality (fixes #3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ sphinx_ts_src_dirs = ['src', 'lib']  # Directories to scan for TypeScript files
 sphinx_ts_exclude_patterns = ['**/*.test.ts', '**/*.spec.ts']  # Files to exclude
 sphinx_ts_include_private = False  # Include private members
 sphinx_ts_include_inherited = True  # Include inherited members
+
+# Source linking configuration
+sphinx_ts_show_source_links = True  # Show links to source code
+sphinx_ts_source_base_url = 'https://github.com/yourusername/yourproject'  # Base URL for source links
+sphinx_ts_source_branch = 'main'  # Git branch to link to
+# Or use a custom URL template:
+# sphinx_ts_source_url_template = 'https://github.com/user/repo/blob/{branch}/{path}'
 ```
 
 ## Usage
@@ -143,6 +150,18 @@ For classes, the extension shows:
 - Implemented interfaces
 - Inherited methods and properties
 
-### (TODO) Source Links
+### Source Links
 
-Each documented item includes a reference to its source file for easy navigation.
+Each documented item includes a reference to its source file for easy navigation. Configure source linking with:
+
+```python
+# In conf.py
+sphinx_ts_show_source_links = True  # Enable source links (default: True)
+sphinx_ts_source_base_url = 'https://github.com/yourusername/yourproject'  # Base repository URL
+sphinx_ts_source_branch = 'main'  # Git branch to link to (default: 'main')
+
+# Or use a custom URL template for more control:
+sphinx_ts_source_url_template = 'https://github.com/{user}/{repo}/blob/{branch}/{path}'
+```
+
+Source links will automatically include line numbers when available, linking directly to the specific location where each class, interface, enum, or function is defined.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,11 @@ sphinx_ts_include_private = True
 # Whether to include inherited members in class documentation
 sphinx_ts_include_inherited = True
 
+# Source linking configuration
+sphinx_ts_show_source_links = True
+sphinx_ts_source_base_url = "https://github.com/snus-kin/sphinx-ts"
+sphinx_ts_source_branch = "master"
+
 # -- Intersphinx Configuration ----------------------------------------------
 
 intersphinx_mapping = {

--- a/src/sphinx_ts/__init__.py
+++ b/src/sphinx_ts/__init__.py
@@ -37,6 +37,21 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value(
         "sphinx_ts_include_inherited", default=True, rebuild="env", types=[bool]
     )
+    app.add_config_value(
+        "sphinx_ts_source_url_template",
+        default=None,
+        rebuild="env",
+        types=[str],
+    )
+    app.add_config_value(
+        "sphinx_ts_source_base_url", default=None, rebuild="env", types=[str]
+    )
+    app.add_config_value(
+        "sphinx_ts_source_branch", default="main", rebuild="env", types=[str]
+    )
+    app.add_config_value(
+        "sphinx_ts_show_source_links", default=True, rebuild="env", types=[bool]
+    )
 
     return {
         "version": "0.1.0",

--- a/src/sphinx_ts/directives/class_directive.py
+++ b/src/sphinx_ts/directives/class_directive.py
@@ -36,6 +36,7 @@ class TSAutoClassDirective(TSAutoDirective):
             return []
 
         ts_class: TSClass = result["object"]
+        file_path = result["file_path"]
 
         # Register methods and properties with domain
         self._register_members_with_domain(
@@ -49,6 +50,9 @@ class TSAutoClassDirective(TSAutoDirective):
 
         # Create standardized signature
         self._create_standard_signature(class_sig, class_name, "class")
+
+        # Add inline source link to signature
+        self._add_source_link_to_signature(class_sig, file_path, ts_class)
 
         # Add standardized documentation content
         self._add_standard_doc_content(class_content, ts_class.doc_comment)

--- a/src/sphinx_ts/directives/data_directive.py
+++ b/src/sphinx_ts/directives/data_directive.py
@@ -68,6 +68,7 @@ class TSAutoDataDirective(TSAutoDirective):
             return []
 
         ts_variable: TSVariable = result["object"]
+        file_path = result["file_path"]
 
         # Create standardized variable descriptor
         var_node, var_sig, var_content = self._create_standard_desc_node(
@@ -89,6 +90,10 @@ class TSAutoDataDirective(TSAutoDirective):
 
         # Add standardized documentation content (skip params for now, handle
         # separately)
+        # Add inline source link to signature
+        self._add_source_link_to_signature(var_sig, file_path, ts_variable)
+
+        # Add standardized documentation content
         self._add_standard_doc_content(
             var_content, ts_variable.doc_comment, skip_params=True
         )
@@ -282,6 +287,7 @@ class TSAutoDataDirective(TSAutoDirective):
     ) -> list[nodes.Node]:
         """Process a TypeScript function."""
         ts_function = result["object"]
+        file_path = result["file_path"]
 
         # Create standardized function descriptor
         func_node, func_sig, func_content = self._create_standard_desc_node(
@@ -313,6 +319,9 @@ class TSAutoDataDirective(TSAutoDirective):
             formatted_type = self.format_parameter_type(ts_function.return_type)
             func_sig += nodes.emphasis("", formatted_type)
 
+        # Add inline source link to signature
+        self._add_source_link_to_signature(func_sig, file_path, ts_function)
+
         # Add standardized documentation content
         self._add_standard_doc_content(func_content, ts_function.doc_comment)
 
@@ -335,6 +344,7 @@ class TSAutoDataDirective(TSAutoDirective):
     ) -> list[nodes.Node]:
         """Process a TypeScript type alias."""
         type_alias = result["object"]
+        file_path = result["file_path"]
 
         # Create standardized type alias descriptor
         type_node, type_sig, type_content = self._create_standard_desc_node(
@@ -354,6 +364,9 @@ class TSAutoDataDirective(TSAutoDirective):
         if type_def:
             formatted_type_def = self.format_type_annotation(type_def)
             type_sig += nodes.Text(f" = {formatted_type_def}")
+
+        # Add inline source link to signature
+        self._add_source_link_to_signature(type_sig, file_path, type_alias)
 
         # Add standardized documentation content
         doc_comment = type_alias.get("doc_comment")

--- a/src/sphinx_ts/directives/enum_directive.py
+++ b/src/sphinx_ts/directives/enum_directive.py
@@ -40,16 +40,19 @@ class TSAutoEnumDirective(TSAutoDirective):
             return []
 
         ts_enum: TSEnum = result["object"]
+        file_path = result["file_path"]
 
         # Create the main enum documentation
-        return self._create_enum_documentation(ts_enum)
+        return self._create_enum_documentation(ts_enum, file_path)
 
-    def _create_enum_documentation(self, ts_enum: TSEnum) -> list[nodes.Node]:
+    def _create_enum_documentation(
+        self, ts_enum: TSEnum, file_path: str
+    ) -> list[nodes.Node]:
         """Create documentation nodes for an enum."""
         content_nodes = []
 
         # Add enum header
-        self._add_enum_header(ts_enum, content_nodes)
+        self._add_enum_header(ts_enum, content_nodes, file_path)
 
         # Add enum members section
         if ts_enum.members:
@@ -58,7 +61,7 @@ class TSAutoEnumDirective(TSAutoDirective):
         return content_nodes
 
     def _add_enum_header(
-        self, ts_enum: TSEnum, content_nodes: list[nodes.Node]
+        self, ts_enum: TSEnum, content_nodes: list[nodes.Node], file_path: str
     ) -> None:
         """Add the enum header section."""
         # Create standardized enum descriptor
@@ -79,6 +82,9 @@ class TSAutoEnumDirective(TSAutoDirective):
         self._create_standard_signature(
             sig_node, ts_enum.name, "enum", modifiers=modifiers
         )
+
+        # Add inline source link to signature
+        self._add_source_link_to_signature(sig_node, file_path, ts_enum)
 
         # Add standardized documentation content
         self._add_standard_doc_content(desc_content, ts_enum.doc_comment)

--- a/src/sphinx_ts/directives/interface_directive.py
+++ b/src/sphinx_ts/directives/interface_directive.py
@@ -35,6 +35,7 @@ class TSAutoInterfaceDirective(TSAutoDirective):
             return []
 
         ts_interface: TSInterface = result["object"]
+        file_path = result["file_path"]
 
         # Register methods and properties with domain
         self._register_members_with_domain(
@@ -55,6 +56,11 @@ class TSAutoInterfaceDirective(TSAutoDirective):
             "interface",
             type_params=ts_interface.type_parameters,
             extends=ts_interface.extends,
+        )
+
+        # Add inline source link to signature
+        self._add_source_link_to_signature(
+            interface_sig, file_path, ts_interface
         )
 
         # Add standardized documentation content

--- a/src/sphinx_ts/parser/ast_nodes.py
+++ b/src/sphinx_ts/parser/ast_nodes.py
@@ -36,6 +36,8 @@ class TSMember(NamedObjectMixin):
         self.is_readonly = False
         self.is_optional = False
         self.is_export = False
+        self.start_line: int | None = None
+        self.end_line: int | None = None
 
 
 class TSMethod(TSMember):
@@ -90,6 +92,8 @@ class TSClass(NamedObjectMixin):
         self.is_abstract = False
         self.is_export = False
         self.modifiers: list[str] = []
+        self.start_line: int | None = None
+        self.end_line: int | None = None
 
 
 class TSInterface(NamedObjectMixin):
@@ -109,6 +113,8 @@ class TSInterface(NamedObjectMixin):
         self.methods: list[TSMethod] = []
         self.properties: list[TSProperty] = []
         self.is_export = False
+        self.start_line: int | None = None
+        self.end_line: int | None = None
 
 
 class TSVariable(NamedObjectMixin):
@@ -127,6 +133,8 @@ class TSVariable(NamedObjectMixin):
         self.value: str | None = None
         self.kind = "let"  # 'let', 'const', 'var'
         self.is_export = False
+        self.start_line: int | None = None
+        self.end_line: int | None = None
 
 
 class TSEnumMember(NamedObjectMixin):
@@ -161,3 +169,5 @@ class TSEnum(NamedObjectMixin):
         self.is_const = False
         self.is_export = False
         self.is_declare = False
+        self.start_line: int | None = None
+        self.end_line: int | None = None

--- a/src/sphinx_ts/parser/ts_parser.py
+++ b/src/sphinx_ts/parser/ts_parser.py
@@ -203,6 +203,10 @@ class TSParser:
         class_name = self._get_node_text(name_node, source_code)
         class_obj = TSClass(class_name)
 
+        # Add line number tracking
+        class_obj.start_line = node.start_point[0] + 1
+        class_obj.end_line = node.end_point[0] + 1
+
         # Get documentation comment
         class_obj.doc_comment = self._find_doc_comment(node, source_code)
 
@@ -252,6 +256,10 @@ class TSParser:
         method_name = self._get_node_text(name_node, source_code)
         method = TSMethod(method_name)
 
+        # Add line number tracking
+        method.start_line = node.start_point[0] + 1
+        method.end_line = node.end_point[0] + 1
+
         # Get documentation comment
         method.doc_comment = self._find_doc_comment(node, source_code)
 
@@ -279,8 +287,12 @@ class TSParser:
         if not name_node:
             return None
 
-        prop_name = self._get_node_text(name_node, source_code)
-        prop = TSProperty(prop_name)
+        property_name = self._get_node_text(name_node, source_code)
+        prop = TSProperty(property_name)
+
+        # Add line number tracking
+        prop.start_line = node.start_point[0] + 1
+        prop.end_line = node.end_point[0] + 1
 
         # Get documentation comment
         prop.doc_comment = self._find_doc_comment(node, source_code)
@@ -310,6 +322,10 @@ class TSParser:
         interface_name = self._get_node_text(name_node, source_code)
         interface_obj = TSInterface(interface_name)
 
+        # Add line number tracking
+        interface_obj.start_line = node.start_point[0] + 1
+        interface_obj.end_line = node.end_point[0] + 1
+
         # Get documentation comment
         interface_obj.doc_comment = self._find_doc_comment(node, source_code)
 
@@ -337,6 +353,10 @@ class TSParser:
 
         enum_name = self._get_node_text(name_node, source_code)
         enum_obj = TSEnum(enum_name)
+
+        # Add line number tracking
+        enum_obj.start_line = node.start_point[0] + 1
+        enum_obj.end_line = node.end_point[0] + 1
 
         # Get documentation comment
         enum_obj.doc_comment = self._find_doc_comment(node, source_code)
@@ -447,6 +467,10 @@ class TSParser:
         prop_name = self._get_node_text(name_node, source_code)
         prop = TSProperty(prop_name)
 
+        # Add line number tracking
+        prop.start_line = node.start_point[0] + 1
+        prop.end_line = node.end_point[0] + 1
+
         # Parse type annotation
         type_node = node.child_by_field_name("type")
         if type_node:
@@ -466,6 +490,10 @@ class TSParser:
 
         method_name = self._get_node_text(name_node, source_code)
         method = TSMethod(method_name)
+
+        # Add line number tracking
+        method.start_line = node.start_point[0] + 1
+        method.end_line = node.end_point[0] + 1
 
         # Parse parameters
         params_node = node.child_by_field_name("parameters")
@@ -518,6 +546,10 @@ class TSParser:
                     var_name = self._get_node_text(name_node, source_code)
                     var_obj = TSVariable(var_name)
                     var_obj.is_export = is_export
+
+                    # Add line number tracking
+                    var_obj.start_line = child.start_point[0] + 1
+                    var_obj.end_line = child.end_point[0] + 1
 
                     # Try to find doc comment for the variable
                     # First check node (declaration level)
@@ -591,6 +623,10 @@ class TSParser:
         func_name = self._get_node_text(name_node, source_code)
         func = TSMethod(func_name)
         func.kind = "function"
+
+        # Add line number tracking
+        func.start_line = node.start_point[0] + 1
+        func.end_line = node.end_point[0] + 1
 
         # Get documentation comment
         func.doc_comment = self._find_doc_comment(node, source_code)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -25,7 +25,7 @@ from sphinx_ts.parser import (
 
 # Test constants
 EXPECTED_DIRECTIVES_COUNT = 4
-EXPECTED_CONFIG_VALUES_COUNT = 4
+EXPECTED_CONFIG_VALUES_COUNT = 8
 
 
 class MockSphinxApp:
@@ -120,6 +120,10 @@ class TestExtensionSetup:
             ("sphinx_ts_exclude_patterns", [], "env", [list]),
             ("sphinx_ts_include_private", False, "env", [bool]),
             ("sphinx_ts_include_inherited", True, "env", [bool]),
+            ("sphinx_ts_source_url_template", None, "env", [str]),
+            ("sphinx_ts_source_base_url", None, "env", [str]),
+            ("sphinx_ts_source_branch", "main", "env", [str]),
+            ("sphinx_ts_show_source_links", True, "env", [bool]),
         ]
 
         assert len(app.added_config_values) == EXPECTED_CONFIG_VALUES_COUNT

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-ts"
-version = "0.1.1"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "docutils" },


### PR DESCRIPTION
This PR implements the source linking / embedding functionality requested in issue #3.

## Changes Made

### 1. **Line Number Tracking**
- Added  and  attributes to all AST node classes (, , , , )
- Updated the parser to capture line numbers for all TypeScript constructs using Tree-sitter position information

### 2. **Source Link Configuration**
Added new Sphinx configuration options:
-  (default: ) - Enable/disable source links
-  (default: ) - Base URL for repository (e.g., "https://github.com/user/repo")
-  (default: ) - Git branch to link to
-  (default: ) - Custom URL template for advanced use cases

### 3. **Inline Source Link Generation**
- Created  and  methods in the base directive class
- Generates GitHub-style URLs with accurate line numbers (e.g.,  for ranges,  for single lines)
- Handles path resolution correctly when building from docs directory
- Creates properly formatted inline links positioned at the end of signature lines

## Example Configuration

```python
# In conf.py
extensions = [
    'sphinx_ts',
    # other extensions...
]

# Source linking configuration
sphinx_ts_show_source_links = True  # Enable source links (default)
sphinx_ts_source_base_url = 'https://github.com/user/repo'  # Repository URL
sphinx_ts_source_branch = 'master'  # Branch to link to (default: 'main')

# Or use a custom template:
# sphinx_ts_source_url_template = 'https://github.com/{user}/{repo}/blob/{branch}/{path}'
```

Fixes #3